### PR TITLE
jenkins-ptcs-library autofix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ For example, repositories should have
   * README.MD-files
 
 ## Build
-This project requires [dotnet core 2.1](https://www.microsoft.com/net/download)
+This project requires [dotnet core](https://www.microsoft.com/net/download),
+see image used in Jenkinsfile for specific requirements.
 ```
 dotnet build
 ```
@@ -32,6 +33,10 @@ There are 2 main ways to use this project
     dotnet run -- scan-selected --GitHubReporting -r repository-validator
     ```
     * Scanning single repository and reporting to console (validation logic testing)
+    ```
+    dotnet run -- scan-selected -r repository-validator
+    ```
+    * Scanning single repository, reporting to console and creating pull requests when possible.
     ```
     dotnet run -- scan-selected -r repository-validator
     ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For example, repositories should have
   * README.MD-files
 
 ## Build
-This project requires [dotnet core 2.0](https://www.microsoft.com/net/download)
+This project requires [dotnet core 2.1](https://www.microsoft.com/net/download)
 ```
 dotnet build
 ```

--- a/Runner/Options.cs
+++ b/Runner/Options.cs
@@ -12,13 +12,17 @@ namespace Runner
         [Option('g', "GitHubReporting", HelpText = "If enabled, results are reported to GitHub issues")]
         public bool ReportToGithub { get; }
 
+        [Option('a', "AutoFix", HelpText = "If enabled, fixing pull request is automatically created.")]
+        public bool AutoFix { get; }
+
         [Option("CsvFile", HelpText = "If set, results are written to this CSV file. Old file is overridden")]
         public string CsvFile { get; }
 
-        public Options(bool reportToSlack, bool reportToGithub, string csvFile)
+        public Options(bool reportToSlack, bool reportToGithub, bool autoFix, string csvFile)
         {
             ReportToSlack = reportToSlack;
             ReportToGithub = reportToGithub;
+            AutoFix = autoFix;
             CsvFile = csvFile;
         }
     }

--- a/Runner/Program.cs
+++ b/Runner/Program.cs
@@ -64,6 +64,19 @@ namespace Runner
 
                     ReportToConsole(logger, results);
 
+                    if (options.AutoFix)
+                    {
+                        foreach(var result in results)
+                        {
+                            foreach(var x in result.Results)
+                            {
+                                if (!x.IsValid)
+                                {
+                                    x.Fix(ghClient, result.Repository).Wait();
+                                }
+                            }
+                        }
+                    }
                     if (!string.IsNullOrWhiteSpace(options.CsvFile))
                     {
                         ReportToCsv(di.GetService<ILogger<CsvReporter>>(), options.CsvFile, results);

--- a/Runner/Program.cs
+++ b/Runner/Program.cs
@@ -66,14 +66,11 @@ namespace Runner
 
                     if (options.AutoFix)
                     {
-                        foreach(var result in results)
+                        foreach(var repositoryResult in results)
                         {
-                            foreach(var x in result.Results)
+                            foreach(var ruleResult in repositoryResult.Results.Where(r => !r.IsValid))
                             {
-                                if (!x.IsValid)
-                                {
-                                    x.Fix(ghClient, result.Repository).Wait();
-                                }
+                                ruleResult.Fix(ghClient, repositoryResult.Repository).Wait();
                             }
                         }
                     }

--- a/Runner/ScanAllOptions.cs
+++ b/Runner/ScanAllOptions.cs
@@ -7,7 +7,7 @@ namespace Runner
     [Verb("scan-all", HelpText = "Scans all repositories for owner")]
     public class ScanAllOptions : Options
     {
-        public ScanAllOptions(bool reportToSlack, bool reportToGithub, string csvFile) : base(reportToSlack, reportToGithub, csvFile)
+        public ScanAllOptions(bool reportToSlack, bool reportToGithub, bool autoFix, string csvFile) : base(reportToSlack, reportToGithub, autoFix, csvFile)
         {
         }
 
@@ -23,10 +23,11 @@ namespace Runner
             {
                 return new List<Example>
                 {
-                    new Example("Scan all repositories and only report to console", ExampleSettings, new ScanAllOptions(false, false, null)),
-                    new Example("Scan all repositories and report to Slack", ExampleSettings, new ScanAllOptions(true, false, null)),
-                    new Example("Scan all repositories and report to GitHub", ExampleSettings, new ScanAllOptions(false, true, null)),
-                    new Example("Scan all repositories and report to GitHub and Slack", ExampleSettings, new ScanAllOptions(true, true, null)),
+                    new Example("Scan all repositories and only report to console", ExampleSettings, new ScanAllOptions(false, false, false, null)),
+                    new Example("Scan all repositories and report to Slack", ExampleSettings, new ScanAllOptions(true, false, false, null)),
+                    new Example("Scan all repositories and report to GitHub", ExampleSettings, new ScanAllOptions(false, true, false, null)),
+                    new Example("Scan all repositories and report to GitHub and Slack", ExampleSettings, new ScanAllOptions(true, true, false, null)),
+                    new Example("Scan all repositories and create pull requests", ExampleSettings, new ScanAllOptions(false, false, true, null))
                 };
             }
         }

--- a/Runner/ScanSelectedOptions.cs
+++ b/Runner/ScanSelectedOptions.cs
@@ -10,7 +10,7 @@ namespace Runner
         [Option('r', "Repository", Required = true, HelpText = "Name of the scanned repositories (without owner(s))")]
         public IEnumerable<string> Repositories { get; }
 
-        public ScanSelectedOptions(IEnumerable<string> repositories, bool reportToSlack, bool reportToGithub, string csvFile) : base(reportToSlack, reportToGithub, csvFile)
+        public ScanSelectedOptions(IEnumerable<string> repositories, bool reportToSlack, bool reportToGithub, bool autofix, string csvFile) : base(reportToSlack, reportToGithub, autofix, csvFile)
         {
             Repositories = repositories;
         }
@@ -28,11 +28,19 @@ namespace Runner
             {
                 return new List<Example>
                 {
-                    new Example("Scan repository called 'repository-validator' and only report to console", ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, false, false, null)),
-                    new Example("Scan repository called 'repository-validator' and report to Slack", ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, true, false, null)),
-                    new Example("Scan repository called 'repository-validator' and report to GitHub", ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, false, true, null)),
-                    new Example("Scan repository called 'repository-validator' and report to GitHub and Slack", ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, true, true, null)),
-                    new Example("Scan repositories called 'repository-validator', 'repository-2' and 'repository-3' then report to CSV file", ExampleSettings, new ScanSelectedOptions(new []{"repository-validator", "repository-2", "repository-3"}, false, false, "results.csv"))
+                    new Example("Scan repository called 'repository-validator' and only report to console",
+                        ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, false, false, false, null)),
+                    new Example("Scan repository called 'repository-validator' and report to Slack",
+                        ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, true, false, false, null)),
+                    new Example("Scan repository called 'repository-validator' and report to GitHub", 
+                        ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, false, true, false, null)),
+                    new Example("Scan repository called 'repository-validator' and report to GitHub and Slack", 
+                        ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, true, true, false, null)),
+                    new Example("Scan repositories called 'repository-validator', 'repository-2' and 'repository-3' then report to CSV file",
+                        ExampleSettings, new ScanSelectedOptions(new []{"repository-validator", "repository-2", "repository-3"}, false, false, false, "results.csv")),
+                    new Example("Scan repository called 'repository-validator' and create pull request if needed.", 
+                        ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, false, false, true, null)),
+                        
                 };
             }
         }

--- a/ValidationLibrary.GitHub.Tests/GitHubReporterTests.cs
+++ b/ValidationLibrary.GitHub.Tests/GitHubReporterTests.cs
@@ -62,11 +62,7 @@ namespace ValidationLibrary.GitHub.Tests
                 RepositoryName = "repo",
                 Results = new ValidationResult[]
                 {
-                    new ValidationResult
-                    {
-                        IsValid = false,
-                        RuleName = "Rule"
-                    }
+                    new ValidationResult("Rule", "how to fix", false, null)
                 }
             };
 
@@ -84,11 +80,7 @@ namespace ValidationLibrary.GitHub.Tests
                 RepositoryName = "repo",
                 Results = new ValidationResult[]
                 {
-                    new ValidationResult
-                    {
-                        IsValid = false,
-                        RuleName = "Rule"
-                    }
+                    new ValidationResult("Rule", "how to fix", false, null)
                 }
             };
 
@@ -107,11 +99,7 @@ namespace ValidationLibrary.GitHub.Tests
                 RepositoryName = "repo",
                 Results = new ValidationResult[]
                 {
-                    new ValidationResult
-                    {
-                        IsValid = false,
-                        RuleName = "Rule"
-                    }
+                    new ValidationResult("Rule", "how to fix", false, null)
                 }
             };
 
@@ -133,11 +121,7 @@ namespace ValidationLibrary.GitHub.Tests
                 RepositoryName = "repo",
                 Results = new ValidationResult[]
                 {
-                    new ValidationResult
-                    {
-                        IsValid = false,
-                        RuleName = "Rule"
-                    }
+                    new ValidationResult("Rule", "how to fix", false, null)
                 }
             };
 
@@ -159,11 +143,7 @@ namespace ValidationLibrary.GitHub.Tests
                 RepositoryName = "repo",
                 Results = new ValidationResult[]
                 {
-                    new ValidationResult
-                    {
-                        IsValid = true,
-                        RuleName = "Rule"
-                    }
+                    new ValidationResult("Rule", "how to fix", true, null)
                 }
             };
 

--- a/ValidationLibrary/RepositoryValidator.cs
+++ b/ValidationLibrary/RepositoryValidator.cs
@@ -60,6 +60,7 @@ namespace ValidationLibrary
             return new ValidationReport
             {
                 Owner = gitHubRepository.Owner.Login,
+                Repository = gitHubRepository,
                 RepositoryName = gitHubRepository.Name,
                 RepositoryUrl = gitHubRepository.HtmlUrl,
                 Results = validationResults.ToArray()

--- a/ValidationLibrary/Rules/HasDescriptionRule.cs
+++ b/ValidationLibrary/Rules/HasDescriptionRule.cs
@@ -21,6 +21,7 @@ namespace ValidationLibrary.Rules
 
         public Task Init(IGitHubClient ghClient)
         {
+            _logger.LogInformation("Rule {ruleClass} / {ruleName}, Initialized", nameof(HasDescriptionRule), RuleName);
             return Task.FromResult(0);
         }
 

--- a/ValidationLibrary/Rules/HasDescriptionRule.cs
+++ b/ValidationLibrary/Rules/HasDescriptionRule.cs
@@ -34,8 +34,15 @@ namespace ValidationLibrary.Rules
             {
                 RuleName = RuleName,
                 HowToFix = "Add description for this repository.",
-                IsValid = isValid
+                IsValid = isValid,
+                Fix = Fix
             });
+        }
+
+        public Task Fix(IGitHubClient client, Repository repository)
+        {
+            _logger.LogInformation("Rule {ruleClass} / {ruleName}, No fix.", nameof(HasDescriptionRule), RuleName);
+            return Task.FromResult(0);
         }
     }
 }

--- a/ValidationLibrary/Rules/HasDescriptionRule.cs
+++ b/ValidationLibrary/Rules/HasDescriptionRule.cs
@@ -30,16 +30,10 @@ namespace ValidationLibrary.Rules
             _logger.LogTrace("Rule {ruleClass} / {ruleName}, Validating repository {repositoryName}", nameof(HasDescriptionRule), RuleName, gitHubRepository.FullName);
             var isValid = !string.IsNullOrWhiteSpace(gitHubRepository.Description);
             _logger.LogDebug("Rule {ruleClass} / {ruleName}, Validating repository {repositoryName}. Has description: {hasDescription}", nameof(HasDescriptionRule), RuleName, gitHubRepository.FullName, isValid);
-            return Task.FromResult(new ValidationResult
-            {
-                RuleName = RuleName,
-                HowToFix = "Add description for this repository.",
-                IsValid = isValid,
-                Fix = Fix
-            });
+            return Task.FromResult(new ValidationResult(RuleName, "Add description for this repository.", isValid, DoNothing));
         }
 
-        public Task Fix(IGitHubClient client, Repository repository)
+        private Task DoNothing(IGitHubClient client, Repository repository)
         {
             _logger.LogInformation("Rule {ruleClass} / {ruleName}, No fix.", nameof(HasDescriptionRule), RuleName);
             return Task.FromResult(0);

--- a/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
+++ b/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
@@ -90,13 +90,13 @@ namespace ValidationLibrary.Rules
             newTree.Tree.Add(treeItem);
 
             var createdTree = await client.Git.Tree.Create(repository.Owner.Login, repository.Name, newTree);
-            var commit = new NewCommit($"Updated {LibraryName} to latest.", createdTree.Sha, new[] { latest.Sha });
+            var commit = new NewCommit($"Update {LibraryName} to latest versios.", createdTree.Sha, new[] { latest.Sha });
             var commitResponse = await client.Git.Commit.Create(repository.Owner.Login, repository.Name, commit);
 
             var refUpdate = new ReferenceUpdate(commitResponse.Sha);
             await client.Git.Reference.Update(repository.Owner.Login, repository.Name, $"heads/{branchName}", refUpdate);
 
-            var pullRequest = new NewPullRequest($"[Automatic Validation] Updated {LibraryName} to latest.", branchReference.Ref, master.Ref);
+            var pullRequest = new NewPullRequest($"[Automatic Validation] Update {LibraryName} to latest version.", branchReference.Ref, master.Ref);
             pullRequest.Body = "This Pull Request was created by [repository validator](https://github.com/protacon/repository-validator)." + Environment.NewLine +
                                 Environment.NewLine +
                                "To prevent automatic validation, see documentation from [repository validator](https://github.com/protacon/repository-validator)." + Environment.NewLine +

--- a/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
+++ b/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
@@ -52,6 +52,13 @@ namespace ValidationLibrary.Rules
             }
             var fixedContent = _regex.Replace(jenkinsContent.Content, $"'{LibraryName}@{_expectedVersion}'");
 
+            var branches = await client.Repository.Branch.GetAll(repository.Owner.Login, repository.Name);
+            if (branches.Any(branch => branch.Name == branchName))
+            {
+                _logger.LogInformation("Rule {ruleClass} / {ruleName}, Branch {branchName} already exists, skipping fix.",
+                     nameof(HasNewestPtcsJenkinsLibRule), RuleName, branchName);
+                return;
+            }
             var branchReference = await client.Git.Reference.CreateBranch(repository.Owner.Login, repository.Name, branchName);
             var master = await client.Git.Reference.Get(repository.Owner.Login, repository.Name, "heads/master");
 

--- a/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
+++ b/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
@@ -18,9 +18,11 @@ namespace ValidationLibrary.Rules
     {
         private const string JenkinsFileName = "JENKINSFILE";
 
-        public string RuleName => "Old jenkins-ptcs-library";
+        private const string LibraryName = "jenkins-ptcs-library";
 
-        private readonly Regex _regex = new Regex(@"'jenkins-ptcs-library@(\d+.\d+.\d+.*)'", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        public string RuleName => $"Old {LibraryName}";
+
+        private readonly Regex _regex = new Regex($@"'{LibraryName}@(\d+.\d+.\d+.*)'", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private readonly ILogger _logger;
         private string _expectedVersion;
@@ -32,7 +34,7 @@ namespace ValidationLibrary.Rules
 
         public async Task Init(IGitHubClient ghClient)
         {
-            var versionFetcher = new ReleaseVersionFetcher(ghClient, "protacon", "jenkins-ptcs-library");
+            var versionFetcher = new ReleaseVersionFetcher(ghClient, "protacon", LibraryName);
             _expectedVersion = await versionFetcher.GetLatest();
             _logger.LogInformation("Rule {ruleClass} / {ruleName}, Newest version: {expectedVersion}", nameof(HasNewestPtcsJenkinsLibRule), RuleName, _expectedVersion);
         }
@@ -47,7 +49,7 @@ namespace ValidationLibrary.Rules
                 _logger.LogWarning("Rule {ruleClass} / {ruleName}, no jenkins file found, unable to fix.");
                 return;
             }
-            var fixedContent = _regex.Replace(jenkinsContent.Content, $"'jenkins-ptcs-library@{_expectedVersion}'");
+            var fixedContent = _regex.Replace(jenkinsContent.Content, $"'{LibraryName}@{_expectedVersion}'");
 
             var branchReference = await client.Git.Reference.CreateBranch(repository.Owner.Login, repository.Name, "autofix/test");
             var master = await client.Git.Reference.Get(repository.Owner.Login, repository.Name, "heads/master");
@@ -131,7 +133,7 @@ namespace ValidationLibrary.Rules
             return new ValidationResult
             {
                 RuleName = RuleName,
-                HowToFix = "Update jenkins-ptcs-library to newest version.",
+                HowToFix = $"Update {LibraryName} to newest version.",
                 IsValid = group.Value == _expectedVersion,
                 Fix = Fix
             };
@@ -160,7 +162,7 @@ namespace ValidationLibrary.Rules
             return new ValidationResult
             {
                 RuleName = RuleName,
-                HowToFix = "Update jenkins-ptcs-library to newest version.",
+                HowToFix = $"Update {LibraryName} to newest version.",
                 IsValid = true,
                 Fix = Fix
             };

--- a/ValidationLibrary/Rules/HasReadmeRule.cs
+++ b/ValidationLibrary/Rules/HasReadmeRule.cs
@@ -24,6 +24,7 @@ namespace ValidationLibrary.Rules
         
         public Task Init(IGitHubClient ghClient)
         {
+            _logger.LogInformation("Rule {ruleClass} / {ruleName}, Initialized", nameof(HasReadmeRule), RuleName);
             return Task.FromResult(0);
         }
 

--- a/ValidationLibrary/Rules/HasReadmeRule.cs
+++ b/ValidationLibrary/Rules/HasReadmeRule.cs
@@ -1,8 +1,4 @@
-using System;
 using Octokit;
-using System.Linq;
-using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -35,28 +31,16 @@ namespace ValidationLibrary.Rules
             {
                 var readme = await client.Repository.Content.GetReadme(gitHubRepository.Owner.Login, gitHubRepository.Name);
                 _logger.LogDebug("Rule {ruleClass} / {ruleName}, Validating repository {repositoryName}. Readme has content: {readmeHasContent}", nameof(HasReadmeRule), RuleName, gitHubRepository.FullName, !string.IsNullOrWhiteSpace(readme.Content));
-                return new ValidationResult
-                {
-                    RuleName = RuleName,
-                    HowToFix = "Add Readme.md file to repository root with content describing this repository.",
-                    IsValid = !string.IsNullOrWhiteSpace(readme.Content),
-                    Fix = Fix
-                };
+                return new ValidationResult(RuleName, "Add Readme.md file to repository root with content describing this repository.", !string.IsNullOrWhiteSpace(readme.Content), DoNothing);
             } 
             catch (Octokit.NotFoundException)
             {
                 _logger.LogDebug("Rule {ruleClass} / {ruleName}, No Readme found, validation false.", nameof(HasReadmeRule), RuleName);
-                return new ValidationResult
-                {
-                    RuleName = RuleName,
-                    HowToFix = "Add Readme.md file to repository root.",
-                    IsValid = false,
-                    Fix = Fix
-                };
+                return new ValidationResult(RuleName, "Add Readme.md file to repository root.", false, DoNothing);
             }
         }
 
-        public Task Fix(IGitHubClient client, Repository repository)
+        private Task DoNothing(IGitHubClient client, Repository repository)
         {
             _logger.LogInformation("Rule {ruleClass} / {ruleName}, No fix.", nameof(HasReadmeRule), RuleName);
             return Task.FromResult(0);

--- a/ValidationLibrary/Rules/HasReadmeRule.cs
+++ b/ValidationLibrary/Rules/HasReadmeRule.cs
@@ -39,7 +39,8 @@ namespace ValidationLibrary.Rules
                 {
                     RuleName = RuleName,
                     HowToFix = "Add Readme.md file to repository root with content describing this repository.",
-                    IsValid = !string.IsNullOrWhiteSpace(readme.Content)
+                    IsValid = !string.IsNullOrWhiteSpace(readme.Content),
+                    Fix = Fix
                 };
             } 
             catch (Octokit.NotFoundException)
@@ -49,9 +50,16 @@ namespace ValidationLibrary.Rules
                 {
                     RuleName = RuleName,
                     HowToFix = "Add Readme.md file to repository root.",
-                    IsValid = false
+                    IsValid = false,
+                    Fix = Fix
                 };
             }
+        }
+
+        public Task Fix(IGitHubClient client, Repository repository)
+        {
+            _logger.LogInformation("Rule {ruleClass} / {ruleName}, No fix.", nameof(HasReadmeRule), RuleName);
+            return Task.FromResult(0);
         }
     }
 }

--- a/ValidationLibrary/Rules/IValidationRule.cs
+++ b/ValidationLibrary/Rules/IValidationRule.cs
@@ -14,5 +14,7 @@ namespace ValidationLibrary.Rules
         Task Init(IGitHubClient ghClient);
         
         Task<ValidationResult> IsValid(IGitHubClient client, Repository repository);
+
+        Task Fix(IGitHubClient client, Repository repository);
     }
 }

--- a/ValidationLibrary/Rules/IValidationRule.cs
+++ b/ValidationLibrary/Rules/IValidationRule.cs
@@ -14,7 +14,5 @@ namespace ValidationLibrary.Rules
         Task Init(IGitHubClient ghClient);
         
         Task<ValidationResult> IsValid(IGitHubClient client, Repository repository);
-
-        Task Fix(IGitHubClient client, Repository repository);
     }
 }

--- a/ValidationLibrary/ValidationReport.cs
+++ b/ValidationLibrary/ValidationReport.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+using Octokit;
 
 namespace ValidationLibrary
 {
@@ -10,6 +10,7 @@ namespace ValidationLibrary
         public string Owner { get; set; }
         public string RepositoryName { get; set; }
         public string RepositoryUrl { get; set; }
+        public Repository Repository { get; set; }
         public ValidationResult[] Results { get; set; }
     }
 }

--- a/ValidationLibrary/ValidationResult.cs
+++ b/ValidationLibrary/ValidationResult.cs
@@ -9,10 +9,18 @@ namespace ValidationLibrary
     /// </summary>
     public class ValidationResult
     {
-        public string RuleName { get; set; }
-        public string HowToFix { get; set; }
-        public bool IsValid { get; set; }
+        public string RuleName { get; }
+        public string HowToFix { get; }
+        public bool IsValid { get; }
 
-        public Func<GitHubClient, Repository, Task> Fix { get; set; }
+        public Func<GitHubClient, Repository, Task> Fix { get; }
+
+        public ValidationResult(string ruleName, string howToFix, bool isValid, Func<GitHubClient, Repository, Task> fix)
+        {
+            RuleName = ruleName;
+            HowToFix = howToFix;
+            IsValid = isValid;
+            Fix = fix;
+        }
     }
 }

--- a/ValidationLibrary/ValidationResult.cs
+++ b/ValidationLibrary/ValidationResult.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Threading.Tasks;
+using Octokit;
+
 namespace ValidationLibrary
 {
     /// <summary>
@@ -8,5 +12,7 @@ namespace ValidationLibrary
         public string RuleName { get; set; }
         public string HowToFix { get; set; }
         public bool IsValid { get; set; }
+
+        public Func<GitHubClient, Repository, Task> Fix { get; set; }
     }
 }


### PR DESCRIPTION
Added an option to automatically create PR that fixes jenkins-ptcs-library version.

This still needs refactoring and error handling, but the basic functionality is working.

Currently this is only used in console runner.

Closes #60 #54