### PR TITLE
Add license validation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This can be fetched with `Deployment/GetFunctionUri.ps1` or manually from Azure 
 Each repository may contain `repository-validator.json` file which can be used to configure the way that repository is validated.
 Currently it can be used to ignore certain rules by adding the class name to `IgnoredRules` array.
 
-Example `repository-validator.json` file which ignores 3 rules.
+Example `repository-validator.json` file which ignores 4 rules.
 ```
 {
     "Version": "1",
@@ -97,6 +97,7 @@ Example `repository-validator.json` file which ignores 3 rules.
         "HasDescriptionRule",
         "HasNewestPtcsJenkinsLibRule",
         "HasReadmeRule"
+        "HasLicenseRule"
     ]
 }
 ```

--- a/ValidationLibrary.Tests/Rules/HasLicenseRuleTests.cs
+++ b/ValidationLibrary.Tests/Rules/HasLicenseRuleTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NUnit.Framework;
+using Octokit;
+using ValidationLibrary.Rules;
+
+namespace ValidationLibrary.Tests.Rules
+{
+    public class HasLicenseRuleTests
+    {
+        private HasLicenseRule _rule;
+        
+        private IGitHubClient _mockClient;
+
+
+        [SetUp]
+        public void Setup()
+        {
+            _mockClient = Substitute.For<IGitHubClient>();
+            _rule = new HasLicenseRule(Substitute.For<ILogger>());
+        }
+
+        [Test]
+        public void RuleName_IsDefined()
+        {
+            Assert.IsFalse(string.IsNullOrWhiteSpace(_rule.RuleName));
+        }
+
+        [Test]
+        public async Task IsValid_ReturnsOkForPrivateRepository()
+        {
+            var repository = CreateRepository("repomen", true, null);
+
+            var result = await _rule.IsValid(_mockClient, repository);
+            Assert.IsTrue(result.IsValid);
+        }
+
+        [Test]
+        public async Task IsValid_ReturnsOkForPublicRepositoryWithLicense()
+        {
+            LicenseMetadata license = new LicenseMetadata("key", "node", "name", "spdxID", "url", false);
+
+            var repository = CreateRepository("repomen", false, license);
+
+            var result = await _rule.IsValid(_mockClient, repository);
+            Assert.IsTrue(result.IsValid);
+        }
+
+        [Test]
+        public async Task IsValid_ReturnsInvalidForPublicRepositoryWithLicense()
+        {
+            var repository = CreateRepository("repomen", false, null);
+
+            var result = await _rule.IsValid(_mockClient, repository);
+            Assert.IsFalse(result.IsValid);
+        }
+
+        private Repository CreateRepository(string name, bool isPrivate, LicenseMetadata license)
+        {
+            return new Repository(null, null, null, null, null, null, null, 0, null, null, name, null, null, null, null, isPrivate, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, license, false, false, false, false, 0, 0, null, null, null, false);
+        }
+    }
+}

--- a/ValidationLibrary/RepositoryValidator.cs
+++ b/ValidationLibrary/RepositoryValidator.cs
@@ -23,7 +23,8 @@ namespace ValidationLibrary
             {
                 new HasDescriptionRule(logger),
                 new HasReadmeRule(logger),
-                new HasNewestPtcsJenkinsLibRule(logger)
+                new HasNewestPtcsJenkinsLibRule(logger),
+                new HasLicenseRule(logger)
             };
 
             logger.LogInformation("Creating {className} with rules: {rules}", nameof(RepositoryValidator), string.Join(", ", _rules.Select(rule => rule.RuleName)));;

--- a/ValidationLibrary/Rules/HasDescriptionRule.cs
+++ b/ValidationLibrary/Rules/HasDescriptionRule.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Octokit;

--- a/ValidationLibrary/Rules/HasLicenseRule.cs
+++ b/ValidationLibrary/Rules/HasLicenseRule.cs
@@ -1,0 +1,48 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Octokit;
+
+namespace ValidationLibrary.Rules
+{
+    public class HasLicenseRule : IValidationRule
+    {
+        public string RuleName => $"Missing License";
+
+        private const string HowToFix = "Add a license for this repository. See [help](https://help.github.com/en/articles/licensing-a-repository) for guidance. Private repositories don't need a license.";
+
+        private readonly ILogger _logger;
+
+        public HasLicenseRule(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public Task Init(IGitHubClient ghClient)
+        {
+            _logger.LogInformation("Rule {ruleClass} / {ruleName}, Initialized", nameof(HasLicenseRule), RuleName);
+            return Task.FromResult(0);
+        }
+
+        public Task<ValidationResult> IsValid(IGitHubClient client, Repository repository)
+        {
+            _logger.LogTrace("Rule {ruleClass} / {ruleName}, Validating repository {repositoryName}", nameof(HasLicenseRule), RuleName, repository.FullName);
+            if (repository.Private)
+            {
+                return Task.FromResult(new ValidationResult(RuleName, HowToFix, true, DoNothing));
+            }
+            if (repository.License == null)
+            {
+                return Task.FromResult(new ValidationResult(RuleName, HowToFix, false, DoNothing));
+            }
+            _logger.LogTrace("License found {key}", repository.License.Name);
+
+            return Task.FromResult(new ValidationResult(RuleName, HowToFix, true, DoNothing));
+        }
+
+        private Task DoNothing(IGitHubClient client, Repository repository)
+        {
+            _logger.LogInformation("Rule {ruleClass} / {ruleName}, No fix.", nameof(HasLicenseRule), RuleName);
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/ValidationLibrary/Rules/HasLicenseRule.cs
+++ b/ValidationLibrary/Rules/HasLicenseRule.cs
@@ -4,6 +4,9 @@ using Octokit;
 
 namespace ValidationLibrary.Rules
 {
+    /// <summary>
+    /// This rule checks that a public repository has a license.
+    /// </summary>
     public class HasLicenseRule : IValidationRule
     {
         public string RuleName => $"Missing License";


### PR DESCRIPTION
License validation verifies that public repositories have a license file (actual content is not verified, we don't care about that.)

Closes #6 