### PR TITLE
Added release list link to jenkins-ptcs-library validation

### DIFF
--- a/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
+++ b/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
@@ -184,7 +184,7 @@ namespace ValidationLibrary.Rules
 
         private ValidationResult OkResult()
         {
-            return new ValidationResult(RuleName, $"Update {LibraryName} to newest version.", true, DoNothing);
+            return new ValidationResult(RuleName, $"Update {LibraryName} to newest version. Newest version can be found in https://github.com/protacon/{LibraryName}/releases", true, DoNothing);
         }
 
         private Task DoNothing(IGitHubClient client, Repository repository)


### PR DESCRIPTION
Added link to release page of jenkins-ptcs-library so it's easier for new (and old) developers to know where the new library version can be checked.

Newest library version is not added to message because it can change before the issue is fixed and the issue text is currently not changed after first creation.

Closes #53 