### PR TITLE
Fix dependency injection issue with logging

### DIFF
--- a/ValidationLibrary/RepositoryValidator.cs
+++ b/ValidationLibrary/RepositoryValidator.cs
@@ -11,12 +11,12 @@ namespace ValidationLibrary
     {
         private const string ConfigFileName = "repository-validator.json";
 
-        private readonly ILogger _logger;
+        private readonly ILogger<RepositoryValidator> _logger;
 
         private readonly IValidationRule[] _rules;
-        private readonly GitHubClient _gitHubClient;
+        private readonly IGitHubClient _gitHubClient;
 
-        public RepositoryValidator(ILogger logger, GitHubClient gitHubClient)
+        public RepositoryValidator(ILogger<RepositoryValidator> logger, IGitHubClient gitHubClient)
         {
             _rules = new IValidationRule[]
             {

--- a/ValidationLibrary/ValidationResult.cs
+++ b/ValidationLibrary/ValidationResult.cs
@@ -13,9 +13,9 @@ namespace ValidationLibrary
         public string HowToFix { get; }
         public bool IsValid { get; }
 
-        public Func<GitHubClient, Repository, Task> Fix { get; }
+        public Func<IGitHubClient, Repository, Task> Fix { get; }
 
-        public ValidationResult(string ruleName, string howToFix, bool isValid, Func<GitHubClient, Repository, Task> fix)
+        public ValidationResult(string ruleName, string howToFix, bool isValid, Func<IGitHubClient, Repository, Task> fix)
         {
             RuleName = ruleName;
             HowToFix = howToFix;


### PR DESCRIPTION
Dependency injection didn't inject Ilogger without generic parameter, so this was added to `ValidationLibrary.RepositoryValidator`

Console runner was also changed to use dependency injection in similar way to catch these issues.

In future, there should be somekind of automatic test that these are handled.