### PR TITLE
Properly handle archived repositories

### DIFF
--- a/Runner/Program.cs
+++ b/Runner/Program.cs
@@ -88,8 +88,12 @@ namespace Runner
                 })
                 .WithParsed<ScanAllOptions>(options =>
                 {
-                    var allRepositories = ghClient.Repository.GetAllForOrg(githubConfig.Organization).Result;
-                    scanner(allRepositories.Select(r => r.Name).ToArray(), options);
+                    var allNonArchivedRepositories = ghClient
+                        .Repository
+                        .GetAllForOrg(githubConfig.Organization)
+                        .Result
+                        .Where(repository => !repository.Archived);
+                    scanner(allNonArchivedRepositories.Select(r => r.Name).ToArray(), options);
                 });
             }
         }

--- a/Runner/Program.cs
+++ b/Runner/Program.cs
@@ -41,7 +41,7 @@ namespace Runner
                 var logger = di.GetService<ILogger<Program>>();
                 var githubConfig = di.GetService<GitHubConfiguration>();
                 var ghClient = di.GetService<IGitHubClient>();
-                var repositoryValidator = di.GetService<ValidationLibrary.RepositoryValidator>();
+                var repositoryValidator = di.GetService<RepositoryValidator>();
                 var client = di.GetService<ValidationClient>();
                 client.Init().Wait();
 
@@ -160,7 +160,7 @@ namespace Runner
                     loggingBuilder.AddConfiguration(config.GetSection("Logging"));
                     loggingBuilder.AddConsole();
                 })
-                .AddTransient<GitHubConfiguration>(services =>
+                .AddTransient(services =>
                 {
                     var githubConfig = new GitHubConfiguration();
                     config.GetSection("GitHub").Bind(githubConfig);
@@ -173,7 +173,7 @@ namespace Runner
                     return CreateClient(services.GetService<GitHubConfiguration>());
                 })
                 .AddTransient<ValidationClient>()
-                .AddTransient<ValidationLibrary.RepositoryValidator>()
+                .AddSingleton<RepositoryValidator>()
                 .BuildServiceProvider();
         }
 

--- a/ValidationLibrary.GitHub/GitHubReporter.cs
+++ b/ValidationLibrary.GitHub/GitHubReporter.cs
@@ -28,6 +28,11 @@ namespace ValidationLibrary.GitHub
             foreach (var report in reports)
             {
                 var repository = await _client.Repository.Get(report.Owner, report.RepositoryName);
+                if (repository.Archived)
+                {
+                    _logger.LogWarning("Repository {owner}/{repositoryName} is archived. Skipping reporting.", report.Owner, report.RepositoryName);
+                    continue;
+                }
                 using (_logger.BeginScope(ScopeParameters(report)))
                 {
                     if (!repository.HasIssues)

--- a/ValidationLibrary/RepositoryValidator.cs
+++ b/ValidationLibrary/RepositoryValidator.cs
@@ -28,7 +28,7 @@ namespace ValidationLibrary
 
             _logger = logger ?? throw new System.ArgumentNullException(nameof(logger));
             _gitHubClient = gitHubClient ?? throw new System.ArgumentNullException(nameof(gitHubClient));
-            logger.LogInformation("Creating {className} with rules: {rules}", nameof(RepositoryValidator), string.Join(", ", _rules.Select(rule => rule.RuleName)));;
+            logger.LogInformation("Creating {className} with rules: {rules}", nameof(RepositoryValidator), string.Join(", ", _rules.Select(rule => rule.RuleName))); ;
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace ValidationLibrary
             _logger.LogTrace("Validating repository {repositoryName}", gitHubRepository.FullName);
             var config = await GetConfig(gitHubRepository);
 
-            var filteredRules = _rules.Where(rule => 
+            var filteredRules = _rules.Where(rule =>
             {
                 var name = rule.GetType().Name;
                 var isIgnored = config.IgnoredRules.Contains(name);
@@ -69,14 +69,17 @@ namespace ValidationLibrary
 
         private async Task<ValidationConfiguration> GetConfig(Repository gitHubRepository)
         {
-            try {
+            try
+            {
                 _logger.LogTrace("Retrieving config for {repositoryName}", gitHubRepository.FullName);
                 var contents = await _gitHubClient.Repository.Content.GetAllContents(gitHubRepository.Owner.Login, gitHubRepository.Name, ConfigFileName);
                 var jsonContent = contents.FirstOrDefault().Content;
                 var config = JsonConvert.DeserializeObject<ValidationConfiguration>(jsonContent);
                 _logger.LogDebug("Configuration found for {repositoryName}. Ignored rules: {rules}", gitHubRepository.FullName, string.Join(",", config.IgnoredRules));
                 return config;
-            } catch (Octokit.NotFoundException) {
+            }
+            catch (Octokit.NotFoundException)
+            {
                 _logger.LogDebug("No {configFileName} found in {repositoryName}. Using default config.", ConfigFileName, gitHubRepository.FullName);
                 return new ValidationConfiguration();
             }

--- a/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
+++ b/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
@@ -23,7 +23,7 @@ namespace ValidationLibrary.Rules
 
         public string RuleName => $"Old {LibraryName}";
 
-        private readonly Regex _regex = new Regex($@"'{LibraryName}@(\d+.\d+.\d+.*)'", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private readonly Regex _regex = new Regex($@"[""']{LibraryName}@(\d+.\d+.\d+.*)[""']", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private readonly ILogger _logger;
         private string _expectedVersion;
@@ -156,12 +156,14 @@ namespace ValidationLibrary.Rules
             var match = matches.OfType<Match>().FirstOrDefault();
             if (match == null)
             {
+                _logger.LogTrace("Rule {ruleClass} / {ruleName}, no jenkins-ptcs-library matches found. Skipping.", nameof(HasNewestPtcsJenkinsLibRule), RuleName, JenkinsFileName);
                 return OkResult();
             }
 
             var group = match.Groups.OfType<Group>().LastOrDefault();
             if (group == null)
             {
+                _logger.LogTrace("Rule {ruleClass} / {ruleName}, no jenkins-ptcs-library groups found. Skipping.", nameof(HasNewestPtcsJenkinsLibRule), RuleName, JenkinsFileName);
                 return OkResult();
             }
 


### PR DESCRIPTION
* `scan-all` option now skips archived repositories
* `GitHubReporter` skips archived repositories. Warning is logged when `ValidationReport` has archived repository.
  * -> `scan-single` with GitHub reporting doesn't try to report to GitHub if repository is archived. warning is logged instead.

Closes #92 
Closes #93