### PR TITLE
Update existing pull requests for updated jenkins-ptcs-library

### DIFF
--- a/Runner/DebugTestOptions.cs
+++ b/Runner/DebugTestOptions.cs
@@ -13,9 +13,5 @@ namespace Runner
 
         [Option("PullRequestNumber", HelpText = "Number of the Pull Request to be checked", Required = true)]
         public int PullRequestNumber { get; set; }
-
-        public DebugTestOptions()
-        {
-        }
     }
 }

--- a/Runner/DebugTestOptions.cs
+++ b/Runner/DebugTestOptions.cs
@@ -3,10 +3,10 @@ using CommandLine;
 namespace Runner
 {
     /// <summary>
-    /// Debugging help for stuff.
+    /// Debugging help for tool development. Append when needed
     /// </summary>
-    [Verb("git-test", HelpText = "Debug help", Hidden = true)]
-    public class GitTestOptions
+    [Verb("git-test", HelpText = "Checks if PR has live branch.", Hidden = true)]
+    public class DebugTestOptions
     {
         [Option('r', "Repository", Required = true, HelpText = "Name of the scanned repository (without owner)")]
         public string Repository { get; set; }
@@ -14,7 +14,7 @@ namespace Runner
         [Option("PullRequestNumber", HelpText = "Number of the Pull Request to be checked", Required = true)]
         public int PullRequestNumber { get; set; }
 
-        public GitTestOptions()
+        public DebugTestOptions()
         {
         }
     }

--- a/Runner/GitTestOptions.cs
+++ b/Runner/GitTestOptions.cs
@@ -1,0 +1,21 @@
+using CommandLine;
+
+namespace Runner
+{
+    /// <summary>
+    /// Debugging help for stuff.
+    /// </summary>
+    [Verb("git-test", HelpText = "Debug help", Hidden = true)]
+    public class GitTestOptions
+    {
+        [Option('r', "Repository", Required = true, HelpText = "Name of the scanned repository (without owner)")]
+        public string Repository { get; set; }
+
+        [Option("PullRequestNumber", HelpText = "Number of the Pull Request to be checked", Required = true)]
+        public int PullRequestNumber { get; set; }
+
+        public GitTestOptions()
+        {
+        }
+    }
+}

--- a/Runner/Options.cs
+++ b/Runner/Options.cs
@@ -16,7 +16,7 @@ namespace Runner
         [Option("CsvFile", HelpText = "If set, results are written to this CSV file. Old file is overridden")]
         public string CsvFile { get; }
 
-        [Option('f', "ForceAllRules", HelpText = "If enabled, repository-validator.json is ignored in checking.")]
+        [Option('i', "IgnoreRepositoryRules", HelpText = "If enabled, repository-validator.json is ignored in checking.")]
         public bool IgnoreRepositoryRules { get; }
 
         public Options(bool reportToSlack, bool reportToGithub, bool autoFix, string csvFile, bool ignoreRepositoryRules)

--- a/Runner/Options.cs
+++ b/Runner/Options.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using CommandLine;
-using CommandLine.Text;
 
 namespace Runner
 {
@@ -18,12 +16,16 @@ namespace Runner
         [Option("CsvFile", HelpText = "If set, results are written to this CSV file. Old file is overridden")]
         public string CsvFile { get; }
 
-        public Options(bool reportToSlack, bool reportToGithub, bool autoFix, string csvFile)
+        [Option('f', "ForceAllRules", HelpText = "If enabled, repository-validator.json is ignored in checking.")]
+        public bool IgnoreRepositoryRules { get; }
+
+        public Options(bool reportToSlack, bool reportToGithub, bool autoFix, string csvFile, bool ignoreRepositoryRules)
         {
             ReportToSlack = reportToSlack;
             ReportToGithub = reportToGithub;
             AutoFix = autoFix;
             CsvFile = csvFile;
+            IgnoreRepositoryRules = ignoreRepositoryRules;
         }
     }
 }

--- a/Runner/Program.cs
+++ b/Runner/Program.cs
@@ -83,7 +83,7 @@ namespace Runner
                     logger.LogInformation("Duration {duration}", (DateTime.UtcNow - start).TotalSeconds);
                 }
 
-                Parser.Default.ParseArguments<ScanSelectedOptions, ScanAllOptions, GitTestOptions>(args)
+                Parser.Default.ParseArguments<ScanSelectedOptions, ScanAllOptions, DebugTestOptions>(args)
                 .WithParsed<ScanSelectedOptions>(options =>
                 {
                     scanner(options.Repositories, options);
@@ -97,7 +97,7 @@ namespace Runner
                         .Where(repository => !repository.Archived);
                     scanner(allNonArchivedRepositories.Select(r => r.Name).ToArray(), options);
                 })
-                .WithParsed<GitTestOptions>(options =>
+                .WithParsed<DebugTestOptions>(options =>
                 {
                     var utils = di.GetService<GitUtils>();
                     var pr = ghClient.PullRequest.Get(githubConfig.Organization, options.Repository, options.PullRequestNumber).Result;

--- a/Runner/ScanAllOptions.cs
+++ b/Runner/ScanAllOptions.cs
@@ -7,7 +7,7 @@ namespace Runner
     [Verb("scan-all", HelpText = "Scans all repositories for owner")]
     public class ScanAllOptions : Options
     {
-        public ScanAllOptions(bool reportToSlack, bool reportToGithub, bool autoFix, string csvFile) : base(reportToSlack, reportToGithub, autoFix, csvFile)
+        public ScanAllOptions(bool reportToSlack, bool reportToGithub, bool autoFix, string csvFile, bool ignoreRepositoryRules) : base(reportToSlack, reportToGithub, autoFix, csvFile, ignoreRepositoryRules)
         {
         }
 
@@ -23,11 +23,12 @@ namespace Runner
             {
                 return new List<Example>
                 {
-                    new Example("Scan all repositories and only report to console", ExampleSettings, new ScanAllOptions(false, false, false, null)),
-                    new Example("Scan all repositories and report to Slack", ExampleSettings, new ScanAllOptions(true, false, false, null)),
-                    new Example("Scan all repositories and report to GitHub", ExampleSettings, new ScanAllOptions(false, true, false, null)),
-                    new Example("Scan all repositories and report to GitHub and Slack", ExampleSettings, new ScanAllOptions(true, true, false, null)),
-                    new Example("Scan all repositories and create pull requests", ExampleSettings, new ScanAllOptions(false, false, true, null))
+                    new Example("Scan all repositories and only report to console", ExampleSettings, new ScanAllOptions(false, false, false, null, false)),
+                    new Example("Scan all repositories and report to Slack", ExampleSettings, new ScanAllOptions(true, false, false, null, false)),
+                    new Example("Scan all repositories and report to GitHub", ExampleSettings, new ScanAllOptions(false, true, false, null, false)),
+                    new Example("Scan all repositories and report to GitHub and Slack", ExampleSettings, new ScanAllOptions(true, true, false, null, false)),
+                    new Example("Scan all repositories and create pull requests", ExampleSettings, new ScanAllOptions(false, false, true, null, false)),
+                    new Example("Scan all repositories, create pull requests while ignoring repository specific configurations. This is not recommended!", ExampleSettings, new ScanAllOptions(false, false, true, null, false))
                 };
             }
         }

--- a/Runner/ScanSelectedOptions.cs
+++ b/Runner/ScanSelectedOptions.cs
@@ -10,7 +10,7 @@ namespace Runner
         [Option('r', "Repository", Required = true, HelpText = "Name of the scanned repositories (without owner(s))")]
         public IEnumerable<string> Repositories { get; }
 
-        public ScanSelectedOptions(IEnumerable<string> repositories, bool reportToSlack, bool reportToGithub, bool autofix, string csvFile) : base(reportToSlack, reportToGithub, autofix, csvFile)
+        public ScanSelectedOptions(IEnumerable<string> repositories, bool reportToSlack, bool reportToGithub, bool autofix, string csvFile, bool ignoreRepositoryRules) : base(reportToSlack, reportToGithub, autofix, csvFile, ignoreRepositoryRules)
         {
             Repositories = repositories;
         }
@@ -29,17 +29,19 @@ namespace Runner
                 return new List<Example>
                 {
                     new Example("Scan repository called 'repository-validator' and only report to console",
-                        ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, false, false, false, null)),
+                        ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, false, false, false, null, false)),
                     new Example("Scan repository called 'repository-validator' and report to Slack",
-                        ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, true, false, false, null)),
+                        ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, true, false, false, null, false)),
                     new Example("Scan repository called 'repository-validator' and report to GitHub",
-                        ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, false, true, false, null)),
+                        ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, false, true, false, null, false)),
                     new Example("Scan repository called 'repository-validator' and report to GitHub and Slack",
-                        ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, true, true, false, null)),
+                        ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, true, true, false, null, false)),
                     new Example("Scan repositories called 'repository-validator', 'repository-2' and 'repository-3' then report to CSV file",
-                        ExampleSettings, new ScanSelectedOptions(new []{"repository-validator", "repository-2", "repository-3"}, false, false, false, "results.csv")),
+                        ExampleSettings, new ScanSelectedOptions(new []{"repository-validator", "repository-2", "repository-3"}, false, false, false, "results.csv", false)),
                     new Example("Scan repository called 'repository-validator' and create pull request if needed.",
-                        ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, false, false, true, null)),
+                        ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, false, false, true, null, false)),
+                    new Example("Scan repository called 'repository-validator' and create pull request if needed while ignoring repository specific configurations.",
+                        ExampleSettings, new ScanSelectedOptions(new []{"repository-validator"}, false, false, true, null, false)),
 
                 };
             }

--- a/ValidationLibrary.AzureFunctions/RepositoryValidator.cs
+++ b/ValidationLibrary.AzureFunctions/RepositoryValidator.cs
@@ -34,7 +34,7 @@ namespace ValidationLibrary.AzureFunctions
             _logger.LogInformation("Doing validation. Repository {owner}/{repositoryName}", content.Repository?.Owner?.Login, content.Repository?.Name);
 
             await _validationClient.Init();
-            var report = await _validationClient.ValidateRepository(content.Repository.Owner.Login, content.Repository.Name);
+            var report = await _validationClient.ValidateRepository(content.Repository.Owner.Login, content.Repository.Name, false);
 
             _logger.LogDebug("Sending report.");
             await ReportToGitHub(report);

--- a/ValidationLibrary.Tests/Rules/HasLicenseRuleTests.cs
+++ b/ValidationLibrary.Tests/Rules/HasLicenseRuleTests.cs
@@ -11,7 +11,7 @@ namespace ValidationLibrary.Tests.Rules
     public class HasLicenseRuleTests
     {
         private HasLicenseRule _rule;
-        
+
         private IGitHubClient _mockClient;
 
 
@@ -19,7 +19,7 @@ namespace ValidationLibrary.Tests.Rules
         public void Setup()
         {
             _mockClient = Substitute.For<IGitHubClient>();
-            _rule = new HasLicenseRule(Substitute.For<ILogger>());
+            _rule = new HasLicenseRule(Substitute.For<ILogger<HasLicenseRule>>());
         }
 
         [Test]

--- a/ValidationLibrary.Tests/Rules/HasNewestPtcsJenkinsLibRuleTests.cs
+++ b/ValidationLibrary.Tests/Rules/HasNewestPtcsJenkinsLibRuleTests.cs
@@ -11,7 +11,12 @@ namespace ValidationLibrary.Tests.Rules
 {
     public class HasNewestPtcsJenkinsLibRuleTests
     {
-        private const string NewestJenkinsPtcsLibrary = "0.3.2";
+        /// <summary>
+        /// By default, master is checked for Jenkinsfile if there is no branch
+        /// </summary>
+        private const string MasterBranch = "master";
+
+        private const string ExpectedJenkinsPtcsLibrary = "0.3.2";
 
         private HasNewestPtcsJenkinsLibRule _rule;
 
@@ -38,7 +43,7 @@ namespace ValidationLibrary.Tests.Rules
 
             var mockReleaseClient = Substitute.For<IReleasesClient>();
             _mockRepositoryClient.Release.Returns(mockReleaseClient);
-            var release = new Release(null, null, null, null, 0, null, NewestJenkinsPtcsLibrary, null, null, null, false, false, DateTime.UtcNow, null, null, null, null, null);
+            var release = new Release(null, null, null, null, 0, null, ExpectedJenkinsPtcsLibrary, null, null, null, false, false, DateTime.UtcNow, null, null, null, null, null);
             _mockRepositoryClient.Release.GetLatest("protacon", "jenkins-ptcs-library").Returns(Task.FromResult(release));
             await _rule.Init(_mockClient);
         }
@@ -53,7 +58,7 @@ namespace ValidationLibrary.Tests.Rules
         public async Task IsValid_ReturnsOkIFThereIsNoJenkinsFile()
         {
             var repository = CreateRepository("repomen");
-            _mockRepositoryContentClient.GetAllContents(_owner.Name, repository.Name).Returns(Task.FromResult((IReadOnlyList<RepositoryContent>)new List<RepositoryContent>()));
+            _mockRepositoryContentClient.GetAllContentsByRef(_owner.Name, repository.Name, MasterBranch).Returns(Task.FromResult((IReadOnlyList<RepositoryContent>)new List<RepositoryContent>()));
 
             var result = await _rule.IsValid(_mockClient, repository);
             Assert.IsTrue(result.IsValid);
@@ -66,8 +71,8 @@ namespace ValidationLibrary.Tests.Rules
             IReadOnlyList<RepositoryContent> contents = new[] { content };
 
             var repository = CreateRepository("repomen");
-            _mockRepositoryContentClient.GetAllContents(_owner.Name, repository.Name).Returns(Task.FromResult(contents));
-            _mockRepositoryContentClient.GetAllContents(_owner.Name, repository.Name, contents[0].Name).Returns(Task.FromResult(contents));
+            _mockRepositoryContentClient.GetAllContentsByRef(_owner.Name, repository.Name, MasterBranch).Returns(Task.FromResult(contents));
+            _mockRepositoryContentClient.GetAllContentsByRef(_owner.Name, repository.Name, contents[0].Name, MasterBranch).Returns(Task.FromResult(contents));
 
             var result = await _rule.IsValid(_mockClient, repository);
             Assert.IsTrue(result.IsValid);
@@ -80,8 +85,8 @@ namespace ValidationLibrary.Tests.Rules
             IReadOnlyList<RepositoryContent> contents = new[] { content };
 
             var repository = CreateRepository("repomen");
-            _mockRepositoryContentClient.GetAllContents(_owner.Name, repository.Name).Returns(Task.FromResult(contents));
-            _mockRepositoryContentClient.GetAllContents(_owner.Name, repository.Name, contents[0].Name).Returns(Task.FromResult(contents));
+            _mockRepositoryContentClient.GetAllContentsByRef(_owner.Name, repository.Name, MasterBranch).Returns(Task.FromResult(contents));
+            _mockRepositoryContentClient.GetAllContentsByRef(_owner.Name, repository.Name, contents[0].Name, MasterBranch).Returns(Task.FromResult(contents));
 
             var result = await _rule.IsValid(_mockClient, repository);
             Assert.IsFalse(result.IsValid);
@@ -94,8 +99,8 @@ namespace ValidationLibrary.Tests.Rules
             IReadOnlyList<RepositoryContent> contents = new[] { content };
 
             var repository = CreateRepository("repomen");
-            _mockRepositoryContentClient.GetAllContents(_owner.Name, repository.Name).Returns(Task.FromResult(contents));
-            _mockRepositoryContentClient.GetAllContents(_owner.Name, repository.Name, contents[0].Name).Returns(Task.FromResult(contents));
+            _mockRepositoryContentClient.GetAllContentsByRef(_owner.Name, repository.Name, MasterBranch).Returns(Task.FromResult(contents));
+            _mockRepositoryContentClient.GetAllContentsByRef(_owner.Name, repository.Name, contents[0].Name, MasterBranch).Returns(Task.FromResult(contents));
 
             var result = await _rule.IsValid(_mockClient, repository);
             Assert.IsFalse(result.IsValid);
@@ -104,12 +109,12 @@ namespace ValidationLibrary.Tests.Rules
         [Test]
         public async Task IsValid_ReturnsTrueWhenPtcsLibraryIsNewest()
         {
-            var content = CreateContent("JENKINSFILE", $"library 'jenkins-ptcs-library@{NewestJenkinsPtcsLibrary}'");
+            var content = CreateContent("JENKINSFILE", $"library 'jenkins-ptcs-library@{ExpectedJenkinsPtcsLibrary}'");
             IReadOnlyList<RepositoryContent> contents = new[] { content };
 
             var repository = CreateRepository("repomen");
-            _mockRepositoryContentClient.GetAllContents(_owner.Name, repository.Name).Returns(Task.FromResult(contents));
-            _mockRepositoryContentClient.GetAllContents(_owner.Name, repository.Name, contents[0].Name).Returns(Task.FromResult(contents));
+            _mockRepositoryContentClient.GetAllContentsByRef(_owner.Name, repository.Name, MasterBranch).Returns(Task.FromResult(contents));
+            _mockRepositoryContentClient.GetAllContentsByRef(_owner.Name, repository.Name, contents[0].Name, MasterBranch).Returns(Task.FromResult(contents));
 
             var result = await _rule.IsValid(_mockClient, repository);
             Assert.IsTrue(result.IsValid);

--- a/ValidationLibrary.Tests/Rules/HasNewestPtcsJenkinsLibRuleTests.cs
+++ b/ValidationLibrary.Tests/Rules/HasNewestPtcsJenkinsLibRuleTests.cs
@@ -6,6 +6,7 @@ using NSubstitute;
 using NUnit.Framework;
 using Octokit;
 using ValidationLibrary.Rules;
+using ValidationLibrary.Utils;
 
 namespace ValidationLibrary.Tests.Rules
 {
@@ -37,9 +38,9 @@ namespace ValidationLibrary.Tests.Rules
             _mockRepositoryContentClient = Substitute.For<IRepositoryContentsClient>();
             _mockRepositoryClient.Content.Returns(_mockRepositoryContentClient);
 
-            var logger = Substitute.For<ILogger>();
-
-            _rule = new HasNewestPtcsJenkinsLibRule(logger);
+            _rule = new HasNewestPtcsJenkinsLibRule(
+                Substitute.For<ILogger<HasNewestPtcsJenkinsLibRule>>(),
+                new GitUtils(Substitute.For<ILogger<GitUtils>>()));
 
             var mockReleaseClient = Substitute.For<IReleasesClient>();
             _mockRepositoryClient.Release.Returns(mockReleaseClient);
@@ -123,7 +124,7 @@ namespace ValidationLibrary.Tests.Rules
         private RepositoryContent CreateContent(string name, string content)
         {
             var bytes = System.Text.Encoding.UTF8.GetBytes(content);
-            var converted = System.Convert.ToBase64String(bytes);
+            var converted = Convert.ToBase64String(bytes);
             return new RepositoryContent(name, null, null, 0, ContentType.File, null, null, null, null, null, converted, null, null);
         }
 

--- a/ValidationLibrary.Tests/Rules/HasNewestPtcsJenkinsLibRuleTests.cs
+++ b/ValidationLibrary.Tests/Rules/HasNewestPtcsJenkinsLibRuleTests.cs
@@ -55,7 +55,7 @@ namespace ValidationLibrary.Tests.Rules
         }
 
         [Test]
-        public async Task IsValid_ReturnsOkIFThereIsNoJenkinsFile()
+        public async Task IsValid_ReturnsOkIfThereIsNoJenkinsFile()
         {
             var repository = CreateRepository("repomen");
             _mockRepositoryContentClient.GetAllContentsByRef(_owner.Name, repository.Name, MasterBranch).Returns(Task.FromResult((IReadOnlyList<RepositoryContent>)new List<RepositoryContent>()));

--- a/ValidationLibrary.Tests/Utils/GitUtilsTests.cs
+++ b/ValidationLibrary.Tests/Utils/GitUtilsTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NUnit.Framework;
+using Octokit;
+using ValidationLibrary.Utils;
+
+namespace ValidationLibrary.Tests.Utils
+{
+    [TestFixture]
+    public class GitUtilsTests
+    {
+        private GitUtils _gitUtils;
+
+        private IGitHubClient _mockClient;
+        private IRepositoryBranchesClient _mockRepositoryBranchesClient;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var mockLogger = Substitute.For<ILogger<GitUtils>>();
+            _gitUtils = new GitUtils(mockLogger);
+
+            _mockClient = Substitute.For<IGitHubClient>();
+            _mockRepositoryBranchesClient = Substitute.For<IRepositoryBranchesClient>();
+            _mockClient.Repository.Branch.Returns(_mockRepositoryBranchesClient);
+        }
+
+        [Test]
+        public async Task PullRequestHasLiveBranch_ReturnTrueIfBranchReferredInPullRequestHasSameSha()
+        {
+            var pullRequest = CreatePullRequest("reference", "shasha");
+            var branch = CreateBranch("reference", "shasha");
+            _mockRepositoryBranchesClient.Get(Arg.Any<string>(), Arg.Any<string>(), "reference").Returns(branch);
+
+            var result = await _gitUtils.PullRequestHasLiveBranch(_mockClient, pullRequest);
+            Assert.True(result);
+        }
+
+        private Branch CreateBranch(string reference, string sha)
+        {
+            var commit = CreateGitReference(reference, sha);
+            return new Branch("name", commit, false);
+        }
+
+        private PullRequest CreatePullRequest(string reference, string sha)
+        {
+            var headReference = CreateGitReference(reference, sha);
+
+            return new PullRequest(0, null, null, null, null, null, null, null, 666, ItemState.Closed, "title", null, DateTime.UtcNow, DateTime.UtcNow, DateTime.UtcNow, DateTime.UtcNow, headReference, null, null, null, null, null, null, null, null, 0, 0, 0, 0, 0, null, false, null, null);
+        }
+
+        private GitReference CreateGitReference(string reference, string sha)
+        {
+            return new GitReference(null, null, null, reference, sha, null, CreateRepository("test"));
+        }
+
+        private Repository CreateRepository(string name)
+        {
+            return new Repository(null, null, null, null, null, null, null, 0, null, CreateUser(), name, null, null, null, null, false, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, null, false, false, false, false, 0, 0, null, null, null, false);
+        }
+
+        private User CreateUser()
+        {
+            return new User(null, null, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, 0, null, 0, 0, false, null, 0, 0, null, "protacon", "protacon", null, 0, null, 0, 0, 0, null, new RepositoryPermissions(), false, null, null);
+        }
+    }
+}

--- a/ValidationLibrary/IValidationClient.cs
+++ b/ValidationLibrary/IValidationClient.cs
@@ -5,6 +5,6 @@ namespace ValidationLibrary
     public interface IValidationClient
     {
         Task Init();
-        Task<ValidationReport> ValidateRepository(string organization, string repositoryName);
+        Task<ValidationReport> ValidateRepository(string organization, string repositoryName, bool overrideRuleIgnore);
     }
 }

--- a/ValidationLibrary/Rules/HasDescriptionRule.cs
+++ b/ValidationLibrary/Rules/HasDescriptionRule.cs
@@ -11,9 +11,9 @@ namespace ValidationLibrary.Rules
     {
         public string RuleName => "Missing description";
 
-        private readonly ILogger _logger;
+        private readonly ILogger<HasDescriptionRule> _logger;
 
-        public HasDescriptionRule(ILogger logger)
+        public HasDescriptionRule(ILogger<HasDescriptionRule> logger)
         {
             _logger = logger;
         }

--- a/ValidationLibrary/Rules/HasLicenseRule.cs
+++ b/ValidationLibrary/Rules/HasLicenseRule.cs
@@ -13,9 +13,9 @@ namespace ValidationLibrary.Rules
 
         private const string HowToFix = "Add a license for this repository. See [help](https://help.github.com/en/articles/licensing-a-repository) for guidance. Private repositories don't need a license.";
 
-        private readonly ILogger _logger;
+        private readonly ILogger<HasLicenseRule> _logger;
 
-        public HasLicenseRule(ILogger logger)
+        public HasLicenseRule(ILogger<HasLicenseRule> logger)
         {
             _logger = logger;
         }

--- a/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
+++ b/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
@@ -22,6 +22,7 @@ namespace ValidationLibrary.Rules
         private readonly string _branchName = $"feature/{LibraryName}-update";
         private readonly string _pullRequestTitle = $"[Automatic Validation] Update {LibraryName} to latest version.";
         private const string FileMode = "100644";
+        private const string MainBranch = "master";
 
         public string RuleName => $"Old {LibraryName}";
 
@@ -156,14 +157,14 @@ namespace ValidationLibrary.Rules
                 Title = _pullRequestTitle,
                 State = ItemState.Open,
                 Body = oldPullRequest.Body,
-                Base = "master"
+                Base = MainBranch
             };
             await client.PullRequest.Update(repository.Owner.Login, repository.Name, oldPullRequest.Number, pullRequest);
         }
 
         private async Task CreateNewPullRequest(IGitHubClient client, Repository repository, Reference latest)
         {
-            var master = await client.Git.Reference.Get(repository.Owner.Login, repository.Name, "heads/master");
+            var master = await client.Git.Reference.Get(repository.Owner.Login, repository.Name, $"heads/{MainBranch}");
             var pullRequest = new NewPullRequest(_pullRequestTitle, latest.Ref, master.Ref)
             {
                 Body = "This Pull Request was created by [repository validator](https://github.com/protacon/repository-validator)." + Environment.NewLine +
@@ -210,7 +211,7 @@ namespace ValidationLibrary.Rules
         {
             _logger.LogTrace("Rule {ruleClass} / {ruleName}, Validating repository {repositoryName}", nameof(HasNewestPtcsJenkinsLibRule), RuleName, repository.FullName);
 
-            var jenkinsContent = await GetJenkinsFileContent(client, repository, "master");
+            var jenkinsContent = await GetJenkinsFileContent(client, repository, MainBranch);
             if (jenkinsContent == null)
             {
                 // This is unlikely to happen.

--- a/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
+++ b/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
@@ -60,7 +60,7 @@ namespace ValidationLibrary.Rules
             string fixedContent = await GetFixedContent(client, repository, latest.Sha);
             if (fixedContent == null)
             {
-                _logger.LogDebug("Rule {ruleClass} / {ruleName}, Branch {branchName} already had latest version fix, skipping updating existing branch.",
+                _logger.LogDebug("Rule {ruleClass} / {ruleName}, Branch {branchName} already had latest version fix or it didn't have Jenkinsfile, skipping updating existing branch.",
                      nameof(HasNewestPtcsJenkinsLibRule), RuleName, _branchName);
                 return;
             }
@@ -146,7 +146,7 @@ namespace ValidationLibrary.Rules
                 return null;
             }
             var fixedContent = _regex.Replace(jenkinsContent.Content, $"'{LibraryName}@{_expectedVersion}'");
-            return string.Equals(fixedContent, jenkinsContent.Content) ? null : fixedContent;
+            return string.Equals(fixedContent, jenkinsContent.Content, StringComparison.InvariantCulture) ? null : fixedContent;
         }
 
         private async Task OpenOldPullRequest(IGitHubClient client, Repository repository, PullRequest oldPullRequest)

--- a/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
+++ b/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
@@ -19,6 +19,7 @@ namespace ValidationLibrary.Rules
         private const string JenkinsFileName = "Jenkinsfile";
 
         private const string LibraryName = "jenkins-ptcs-library";
+        private readonly string BranchName = $"feature/{LibraryName}-update";
         private const string FileMode = "100644";
 
         public string RuleName => $"Old {LibraryName}";
@@ -45,43 +46,62 @@ namespace ValidationLibrary.Rules
         /// </summary>
         /// <param name="client">Github client</param>
         /// <param name="repository">Repository to be fixed</param>
-        /// <returns></returns>
         private async Task Fix(IGitHubClient client, Repository repository)
         {
             // This method should be refactored when we have a better general idea how we want to fix things
-            var branchName = $"feature/{LibraryName}-update";
             _logger.LogInformation("Rule {ruleClass} / {ruleName}, performing auto fix.", nameof(HasNewestPtcsJenkinsLibRule), RuleName);
 
-            var jenkinsContent = await GetJenkinsFileContent(client, repository);
-            if (jenkinsContent == null)
-            {
-                _logger.LogWarning("Rule {ruleClass} / {ruleName}, no {filename} found, unable to fix.",
-                    nameof(HasNewestPtcsJenkinsLibRule), RuleName, JenkinsFileName);
-                return;
-            }
-            var fixedContent = _regex.Replace(jenkinsContent.Content, $"'{LibraryName}@{_expectedVersion}'");
-
             var branches = await client.Repository.Branch.GetAll(repository.Owner.Login, repository.Name);
-            if (branches.Any(branch => branch.Name == branchName))
+            var existingBranch = branches.FirstOrDefault(branch => branch.Name == BranchName);
+
+            Commit latest;
+            if (existingBranch == null)
             {
-                _logger.LogInformation("Rule {ruleClass} / {ruleName}, Branch {branchName} already exists, skipping fix.",
-                     nameof(HasNewestPtcsJenkinsLibRule), RuleName, branchName);
+                _logger.LogInformation("Rule {ruleClass} / {ruleName}, Branch {branchName} did exists, creating branch.",
+                     nameof(HasNewestPtcsJenkinsLibRule), RuleName, BranchName);
+                var branchReference = await client.Git.Reference.CreateBranch(repository.Owner.Login, repository.Name, BranchName);
+                latest = await client.Git.Commit.Get(repository.Owner.Login, repository.Name, branchReference.Object.Sha);
+            }
+            else
+            {
+                _logger.LogInformation("Rule {ruleClass} / {ruleName}, Branch {branchName} already exists, updating existing branch.",
+                     nameof(HasNewestPtcsJenkinsLibRule), RuleName, BranchName);
+                latest = await client.Git.Commit.Get(repository.Owner.Login, repository.Name, existingBranch.Commit.Sha);
+            }
+            string fixedContent = await GetFixedContent(client, repository, existingBranch == null ? "master" : BranchName);
+            if (fixedContent == null)
+            {
+                _logger.LogDebug("Rule {ruleClass} / {ruleName}, Branch {branchName} already had latest version fix, skipping updating existing branch.",
+                     nameof(HasNewestPtcsJenkinsLibRule), RuleName, BranchName);
                 return;
             }
-            var branchReference = await client.Git.Reference.CreateBranch(repository.Owner.Login, repository.Name, branchName);
-            var master = await client.Git.Reference.Get(repository.Owner.Login, repository.Name, "heads/master");
 
-            var latest = await client.Git.Commit.Get(repository.Owner.Login, repository.Name, branchReference.Object.Sha);
-            _logger.LogTrace("Latest commit with message {a}", latest.Message);
+            await PushFix(client, repository, latest, fixedContent);
 
+            var pullRequest = new PullRequestRequest
+            {
+                State = ItemStateFilter.Open
+            };
+            var pullRequests = await client.PullRequest.GetAllForRepository(repository.Owner.Login, repository.Name, pullRequest);
+            if (pullRequests.Any(pr => pr.Title == $"[Automatic Validation] Update {LibraryName} to latest version."))
+            {
+                _logger.LogInformation("Rule {ruleClass} / {ruleName}, Open pull request already exists. Skipping.", nameof(HasNewestPtcsJenkinsLibRule), RuleName);
+                return;
+            }
+
+            await CreateNewPullRequest(client, repository, latest);
+        }
+
+        private async Task PushFix(IGitHubClient client, Repository repository, Commit latest, string jenkinsFile)
+        {
+            _logger.LogTrace("Latest commit with message {message}", latest.Message);
             var oldTree = await client.Git.Tree.Get(repository.Owner.Login, repository.Name, latest.Sha);
             var newTree = new NewTree
             {
                 BaseTree = oldTree.Sha
             };
 
-            BlobReference blobReference = await CreateBlob(client, repository, fixedContent);
-
+            BlobReference blobReference = await CreateBlob(client, repository, jenkinsFile);
             var treeItem = new NewTreeItem()
             {
                 Path = JenkinsFileName,
@@ -96,9 +116,27 @@ namespace ValidationLibrary.Rules
             var commitResponse = await client.Git.Commit.Create(repository.Owner.Login, repository.Name, commit);
 
             var refUpdate = new ReferenceUpdate(commitResponse.Sha);
-            await client.Git.Reference.Update(repository.Owner.Login, repository.Name, $"heads/{branchName}", refUpdate);
+            await client.Git.Reference.Update(repository.Owner.Login, repository.Name, $"heads/{BranchName}", refUpdate);
+        }
 
-            var pullRequest = new NewPullRequest($"[Automatic Validation] Update {LibraryName} to latest version.", branchReference.Ref, master.Ref)
+        private async Task<string> GetFixedContent(IGitHubClient client, Repository repository, string branchName)
+        {
+            _logger.LogTrace("Rule {ruleClass} / {ruleName}: Retrieving fixed contents for JenkinsFile from branch {branch}", nameof(HasNewestPtcsJenkinsLibRule), RuleName, branchName);
+            var jenkinsContent = await GetJenkinsFileContent(client, repository, branchName);
+            if (jenkinsContent == null)
+            {
+                _logger.LogWarning("Rule {ruleClass} / {ruleName}, no {filename} found, unable to fix.",
+                    nameof(HasNewestPtcsJenkinsLibRule), RuleName, JenkinsFileName);
+                return null;
+            }
+            var fixedContent = _regex.Replace(jenkinsContent.Content, $"'{LibraryName}@{_expectedVersion}'");
+            return string.Equals(fixedContent, jenkinsContent.Content) ? null : fixedContent;
+        }
+
+        private async Task CreateNewPullRequest(IGitHubClient client, Repository repository, Commit latest)
+        {
+            var master = await client.Git.Reference.Get(repository.Owner.Login, repository.Name, "heads/master");
+            var pullRequest = new NewPullRequest($"[Automatic Validation] Update {LibraryName} to latest version.", latest.Ref, master.Ref)
             {
                 Body = "This Pull Request was created by [repository validator](https://github.com/protacon/repository-validator)." + Environment.NewLine +
                         Environment.NewLine +
@@ -122,12 +160,12 @@ namespace ValidationLibrary.Rules
         }
 
 
-        private async Task<RepositoryContent> GetJenkinsFileContent(IGitHubClient client, Repository repository)
+        private async Task<RepositoryContent> GetJenkinsFileContent(IGitHubClient client, Repository repository, string branch)
         {
-            _logger.LogTrace("Retrieving JenkinsFile for {repositoryName}", repository.FullName);
+            _logger.LogTrace("Retrieving JenkinsFile for {repositoryName} from branch {branch}", repository.FullName, branch);
 
             // NOTE: rootContents doesn't contain actual contents, content is only fetched when we fetch the single file later.
-            var rootContents = await GetContents(client, repository);
+            var rootContents = await GetContents(client, repository, branch);
 
             var jenkinsFile = rootContents.FirstOrDefault(content => content.Name.Equals(JenkinsFileName, StringComparison.InvariantCultureIgnoreCase));
             if (jenkinsFile == null)
@@ -136,7 +174,7 @@ namespace ValidationLibrary.Rules
                 return null;
             }
 
-            var matchingJenkinsFiles = await client.Repository.Content.GetAllContents(repository.Owner.Login, repository.Name, jenkinsFile.Name);
+            var matchingJenkinsFiles = await client.Repository.Content.GetAllContentsByRef(repository.Owner.Login, repository.Name, jenkinsFile.Name, branch);
             return matchingJenkinsFiles.FirstOrDefault();
         }
 
@@ -144,7 +182,7 @@ namespace ValidationLibrary.Rules
         {
             _logger.LogTrace("Rule {ruleClass} / {ruleName}, Validating repository {repositoryName}", nameof(HasNewestPtcsJenkinsLibRule), RuleName, repository.FullName);
 
-            var jenkinsContent = await GetJenkinsFileContent(client, repository);
+            var jenkinsContent = await GetJenkinsFileContent(client, repository, "master");
             if (jenkinsContent == null)
             {
                 // This is unlikely to happen.
@@ -170,13 +208,13 @@ namespace ValidationLibrary.Rules
             return new ValidationResult(RuleName, $"Update {LibraryName} to newest version.", group.Value == _expectedVersion, Fix);
         }
 
-        private async Task<IReadOnlyList<RepositoryContent>> GetContents(IGitHubClient client, Repository repository)
+        private async Task<IReadOnlyList<RepositoryContent>> GetContents(IGitHubClient client, Repository repository, string branch)
         {
             try
             {
-                return await client.Repository.Content.GetAllContents(repository.Owner.Login, repository.Name);
+                return await client.Repository.Content.GetAllContentsByRef(repository.Owner.Login, repository.Name, branch);
             }
-            catch (Octokit.NotFoundException exception)
+            catch (NotFoundException exception)
             {
                 /* 
                  * NOTE: Repository that was just created (empty repository) doesn't have content this causes
@@ -184,7 +222,7 @@ namespace ValidationLibrary.Rules
                  * was missing, but we don't care for that case (no point to validate if repository doesn't exist.)
                  */
                 _logger.LogWarning(exception, "Rule {ruleClass} / {ruleName}, Repository {repositoryName} caused {exceptionClass}. This may be a new repository, but if this persists, repository should be removed.",
-                 nameof(HasNewestPtcsJenkinsLibRule), RuleName, repository.Name, nameof(Octokit.NotFoundException));
+                 nameof(HasNewestPtcsJenkinsLibRule), RuleName, repository.Name, nameof(NotFoundException));
                 return new RepositoryContent[0];
             }
         }

--- a/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
+++ b/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
@@ -20,6 +20,7 @@ namespace ValidationLibrary.Rules
 
         private const string LibraryName = "jenkins-ptcs-library";
         private readonly string BranchName = $"feature/{LibraryName}-update";
+        private readonly string PullRequestTitle = $"[Automatic Validation] Update {LibraryName} to latest version.";
         private const string FileMode = "100644";
 
         public string RuleName => $"Old {LibraryName}";
@@ -67,7 +68,7 @@ namespace ValidationLibrary.Rules
                 State = ItemStateFilter.Open
             };
             var pullRequests = await client.PullRequest.GetAllForRepository(repository.Owner.Login, repository.Name, pullRequest);
-            if (pullRequests.Any(pr => pr.Title == $"[Automatic Validation] Update {LibraryName} to latest version."))
+            if (pullRequests.Any(pr => pr.Title == PullRequestTitle))
             {
                 _logger.LogInformation("Rule {ruleClass} / {ruleName}, Open pull request already exists. Skipping.", nameof(HasNewestPtcsJenkinsLibRule), RuleName);
                 return;
@@ -142,7 +143,7 @@ namespace ValidationLibrary.Rules
         private async Task CreateNewPullRequest(IGitHubClient client, Repository repository, Commit latest)
         {
             var master = await client.Git.Reference.Get(repository.Owner.Login, repository.Name, "heads/master");
-            var pullRequest = new NewPullRequest($"[Automatic Validation] Update {LibraryName} to latest version.", latest.Ref, master.Ref)
+            var pullRequest = new NewPullRequest(PullRequestTitle, latest.Ref, master.Ref)
             {
                 Body = "This Pull Request was created by [repository validator](https://github.com/protacon/repository-validator)." + Environment.NewLine +
                         Environment.NewLine +

--- a/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
+++ b/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
@@ -102,12 +102,10 @@ namespace ValidationLibrary.Rules
                 var branchReference = await client.Git.Reference.CreateBranch(repository.Owner.Login, repository.Name, _branchName);
                 return await client.Git.Commit.Get(repository.Owner.Login, repository.Name, branchReference.Object.Sha);
             }
-            else
-            {
-                _logger.LogInformation("Rule {ruleClass} / {ruleName}, Branch {branchName} already exists, using existing branch.",
-                     nameof(HasNewestPtcsJenkinsLibRule), RuleName, _branchName);
-                return await client.Git.Commit.Get(repository.Owner.Login, repository.Name, existingBranch.Commit.Sha);
-            }
+
+            _logger.LogInformation("Rule {ruleClass} / {ruleName}, Branch {branchName} already exists, using existing branch.",
+                    nameof(HasNewestPtcsJenkinsLibRule), RuleName, _branchName);
+            return await client.Git.Commit.Get(repository.Owner.Login, repository.Name, existingBranch.Commit.Sha);
         }
 
         private async Task<Reference> PushFix(IGitHubClient client, Repository repository, Commit latest, string jenkinsFile)

--- a/ValidationLibrary/Rules/HasReadmeRule.cs
+++ b/ValidationLibrary/Rules/HasReadmeRule.cs
@@ -9,15 +9,15 @@ namespace ValidationLibrary.Rules
     /// </summary>
     public class HasReadmeRule : IValidationRule
     {
-        public string RuleName =>  "Missing Readme.md";
+        public string RuleName => "Missing Readme.md";
 
-        private readonly ILogger _logger;
+        private readonly ILogger<HasReadmeRule> _logger;
 
-        public HasReadmeRule(ILogger logger)
+        public HasReadmeRule(ILogger<HasReadmeRule> logger)
         {
             _logger = logger;
         }
-        
+
         public Task Init(IGitHubClient ghClient)
         {
             _logger.LogInformation("Rule {ruleClass} / {ruleName}, Initialized", nameof(HasReadmeRule), RuleName);
@@ -32,7 +32,7 @@ namespace ValidationLibrary.Rules
                 var readme = await client.Repository.Content.GetReadme(gitHubRepository.Owner.Login, gitHubRepository.Name);
                 _logger.LogDebug("Rule {ruleClass} / {ruleName}, Validating repository {repositoryName}. Readme has content: {readmeHasContent}", nameof(HasReadmeRule), RuleName, gitHubRepository.FullName, !string.IsNullOrWhiteSpace(readme.Content));
                 return new ValidationResult(RuleName, "Add Readme.md file to repository root with content describing this repository.", !string.IsNullOrWhiteSpace(readme.Content), DoNothing);
-            } 
+            }
             catch (Octokit.NotFoundException)
             {
                 _logger.LogDebug("Rule {ruleClass} / {ruleName}, No Readme found, validation false.", nameof(HasReadmeRule), RuleName);

--- a/ValidationLibrary/Utils/GitUtils.cs
+++ b/ValidationLibrary/Utils/GitUtils.cs
@@ -1,0 +1,39 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Octokit;
+
+namespace ValidationLibrary.Utils
+{
+    /// <summary>
+    /// Miscellaneous Git utils
+    /// </summary>
+    public class GitUtils
+    {
+        private readonly ILogger<GitUtils> _logger;
+
+        public GitUtils(ILogger<GitUtils> logger)
+        {
+            _logger = logger ?? throw new System.ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Checks if this pull reqeest has a branch that is alive.
+        /// 
+        /// If branch is not alive, PR can't be opened.
+        /// </summary>
+        /// <param name="client">Client</param>
+        /// <param name="pullRequest">Pull request</param>
+        /// <returns>True if branch is alive, false if not.</returns>
+        public async Task<bool> PullRequestHasLiveBranch(IGitHubClient client, PullRequest pullRequest)
+        {
+            _logger.LogTrace("Pull request head: {ref} {sha} from repostitory {owner}/{name}", pullRequest.Head.Ref, pullRequest.Head.Sha, pullRequest.Head.Repository.Owner.Login, pullRequest.Head.Repository.Name);
+            var owner = pullRequest.Head.Repository.Owner.Login;
+            var repositoryName = pullRequest.Head.Repository.Name;
+
+            var branch = await client.Repository.Branch.Get(owner, repositoryName, pullRequest.Head.Ref);
+            _logger.LogTrace("Refence SHA {sha}", branch.Commit.Sha, branch.Commit.Ref);
+
+            return branch.Commit.Sha == pullRequest.Head.Sha;
+        }
+    }
+}

--- a/ValidationLibrary/Utils/GitUtils.cs
+++ b/ValidationLibrary/Utils/GitUtils.cs
@@ -33,7 +33,7 @@ namespace ValidationLibrary.Utils
             var branch = await client.Repository.Branch.Get(owner, repositoryName, pullRequest.Head.Ref);
             _logger.LogTrace("Refence SHA {sha}", branch.Commit.Sha, branch.Commit.Ref);
 
-            return branch.Commit.Sha == pullRequest.Head.Sha;
+            return string.Equals(branch.Commit.Sha, pullRequest.Head.Sha, System.StringComparison.InvariantCulture);
         }
     }
 }

--- a/ValidationLibrary/ValidationClient.cs
+++ b/ValidationLibrary/ValidationClient.cs
@@ -22,10 +22,10 @@ namespace ValidationLibrary
             await _validator.Init();
         }
 
-        public async Task<ValidationReport> ValidateRepository(string organization, string repositoryName)
+        public async Task<ValidationReport> ValidateRepository(string organization, string repositoryName, bool overrideRuleIgnore)
         {
             var repository = await _client.Repository.Get(organization, repositoryName);
-            var result = await _validator.Validate(repository);
+            var result = await _validator.Validate(repository, overrideRuleIgnore);
             return result;
         }
     }


### PR DESCRIPTION
This updates existing pull requests to latest `jenkins-ptcs-library`

What happens when old library version is noticed in `master`

| Branch | PR | Action |
|-|-|-|
| No branch | No | Create branch & PR |
| No branch | Closed | Create branch & PR |
| No branch | Open | Can't happen in GitHub |
| up-to-date | No | Create PR |
| up-to-date | Closed | Nothing |
| up-to-date | Open | Nothing |
| out-to-date | No | Update branch, Create PR |
| out-to-date | No | Update branch, Create PR |
| out-to-date | No | Update branch, Create PR |

Partially implements #68 