### PR TITLE
Unique resource group name generation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,6 @@ podTemplate(label: pod.label,
 ) {
 
     def branch = (env.BRANCH_NAME)
-    def buildNumber = (env.BUILD_NUMBER)
     def resourceGroup = 'repository-validator-prod'
     def appName = 'ptcs-github-validator'
     def gitHubOrganization = 'protacon'
@@ -50,8 +49,9 @@ podTemplate(label: pod.label,
 
                 if (isTest(branch) || isDependabot(branch)){
                     toAzureTestEnv {
-                        def ciRg = 'repo-ci-' + buildNumber
-                        def ciAppName = 'repo-ci-' + buildNumber
+                        def now = new Date().getTime()
+                        def ciRg = 'repo-ci-' + now
+                        def ciAppName = 'repo-ci-' + now
 
                         stage('Create temporary Resource Group'){
                             sh """


### PR DESCRIPTION
Generates unique resource group name which is used to generate environments. Old names could clash in cases when multiple libraries receive updates at the same time and dependabot creates multiple PR:rs almost simultaneously.

Closes #171 