### PR TITLE
HasReadmeRule - commit fix

### DIFF
--- a/ValidationLibrary.Tests/Rules/HasReadmeRuleTests.cs
+++ b/ValidationLibrary.Tests/Rules/HasReadmeRuleTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -11,6 +12,11 @@ namespace ValidationLibrary.Tests.Rules
 {
     public class HasReadmeRuleTests
     {
+        /// <summary>
+        /// By default, master is checked for Jenkinsfile if there is no branch
+        /// </summary>
+        private const string MasterBranch = "master";
+
         private HasReadmeRule _rule;
 
         private User _owner;
@@ -48,9 +54,11 @@ namespace ValidationLibrary.Tests.Rules
         [Test]
         public async Task IsValid_ReturnsOkWhenReadmeExists()
         {
-            var readme = CreateReadme("README.md", "random content");
+            var readme = CreateContent("README.md", "random content");
+            IReadOnlyList<RepositoryContent> contents = new[] { readme };
             var repository = CreateRepository("repomen");
-            _mockRepositoryContentClient.GetReadme(_owner.Name, repository.Name).Returns(Task.FromResult(readme));
+            _mockRepositoryContentClient.GetAllContentsByRef(_owner.Name, repository.Name, contents[0].Name, MasterBranch).Returns(Task.FromResult(contents));
+            _mockRepositoryContentClient.GetAllContentsByRef(_owner.Name, repository.Name, MasterBranch).Returns(Task.FromResult(contents));
 
             var result = await _rule.IsValid(_mockClient, repository);
             Assert.IsTrue(result.IsValid);
@@ -59,9 +67,11 @@ namespace ValidationLibrary.Tests.Rules
         [Test]
         public async Task IsValid_ReturnsFalseWhenReadmeExistsWithoutContent()
         {
-            var readme = CreateReadme("README.md", "");
+            var readme = CreateContent("README.md", "");
+            IReadOnlyList<RepositoryContent> contents = new[] { readme };
             var repository = CreateRepository("repomen");
-            _mockRepositoryContentClient.GetReadme(_owner.Name, repository.Name).Returns(Task.FromResult(readme));
+            _mockRepositoryContentClient.GetAllContentsByRef(_owner.Name, repository.Name, contents[0].Name, MasterBranch).Returns(Task.FromResult(contents));
+            _mockRepositoryContentClient.GetAllContentsByRef(_owner.Name, repository.Name, MasterBranch).Returns(Task.FromResult(contents));
 
             var result = await _rule.IsValid(_mockClient, repository);
             Assert.IsFalse(result.IsValid);
@@ -71,15 +81,17 @@ namespace ValidationLibrary.Tests.Rules
         public async Task IsValid_ReturnsFalseWhenReadmeDoesNotExist()
         {
             var repository = CreateRepository("repomen");
-            _mockRepositoryContentClient.GetReadme(_owner.Name, repository.Name).Returns(Task.FromResult<Readme>(null));
+            _mockRepositoryContentClient.GetAllContentsByRef(_owner.Name, repository.Name, MasterBranch).Returns(Task.FromResult((IReadOnlyList<RepositoryContent>)new List<RepositoryContent>()));
 
             var result = await _rule.IsValid(_mockClient, repository);
             Assert.IsFalse(result.IsValid);
         }
 
-        private Readme CreateReadme(string name, string content)
+        private RepositoryContent CreateContent(string name, string content)
         {
-            return new Readme(null, content, name, null, null);
+            var bytes = System.Text.Encoding.UTF8.GetBytes(content);
+            var converted = Convert.ToBase64String(bytes);
+            return new RepositoryContent(name, null, null, 0, ContentType.File, null, null, null, null, null, converted, null, null);
         }
 
         private Repository CreateRepository(string name)

--- a/ValidationLibrary.Tests/Rules/HasReadmeRuleTests.cs
+++ b/ValidationLibrary.Tests/Rules/HasReadmeRuleTests.cs
@@ -13,7 +13,7 @@ namespace ValidationLibrary.Tests.Rules
     public class HasReadmeRuleTests
     {
         /// <summary>
-        /// By default, master is checked for Jenkinsfile if there is no branch
+        /// By default, master is checked for README.md if there is no branch
         /// </summary>
         private const string MasterBranch = "master";
 

--- a/ValidationLibrary/Rules/FixableRuleBase.cs
+++ b/ValidationLibrary/Rules/FixableRuleBase.cs
@@ -118,20 +118,9 @@ namespace ValidationLibrary.Rules
 
         protected async Task<IReadOnlyList<RepositoryContent>> GetContents(IGitHubClient client, Repository repository, string branch)
         {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
-            if (repository is null)
-            {
-                throw new ArgumentNullException(nameof(repository));
-            }
-
-            if (string.IsNullOrEmpty(branch))
-            {
-                throw new ArgumentException("branch is missing", nameof(branch));
-            }
+            if (client is null) throw new ArgumentNullException(nameof(client));
+            if (repository is null) throw new ArgumentNullException(nameof(repository));
+            if (string.IsNullOrEmpty(branch)) throw new ArgumentException("branch is missing", nameof(branch));
 
             try
             {

--- a/ValidationLibrary/Rules/FixableRuleBase.cs
+++ b/ValidationLibrary/Rules/FixableRuleBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -113,6 +114,40 @@ namespace ValidationLibrary.Rules
                 Body = PullRequestBody
             };
             await client.PullRequest.Create(repository.Owner.Login, repository.Name, pullRequest).ConfigureAwait(false);
+        }
+
+        protected async Task<IReadOnlyList<RepositoryContent>> GetContents(IGitHubClient client, Repository repository, string branch)
+        {
+            if (client is null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            if (repository is null)
+            {
+                throw new ArgumentNullException(nameof(repository));
+            }
+
+            if (string.IsNullOrEmpty(branch))
+            {
+                throw new ArgumentException("branch is missing", nameof(branch));
+            }
+
+            try
+            {
+                return await client.Repository.Content.GetAllContentsByRef(repository.Owner.Login, repository.Name, branch).ConfigureAwait(false);
+            }
+            catch (NotFoundException exception)
+            {
+                /*
+                 * NOTE: Repository that was just created (empty repository) doesn't have content this causes
+                 * Octokit.NotFoundException. This same thing would probably be throw if the whole repository
+                 * was missing, but we don't care for that case (no point to validate if repository doesn't exist.)
+                 */
+                _logger.LogWarning(exception, "Rule {ruleClass} / {ruleName}, Repository {repositoryName} caused {exceptionClass}. This may be a new repository, but if this persists, repository should be removed.",
+                 nameof(HasNewestPtcsJenkinsLibRule), RuleName, repository.Name, nameof(NotFoundException));
+                return Array.Empty<RepositoryContent>();
+            }
         }
     }
 }

--- a/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
+++ b/ValidationLibrary/Rules/HasNewestPtcsJenkinsLibRule.cs
@@ -170,25 +170,6 @@ namespace ValidationLibrary.Rules
             return matchingJenkinsFiles[0];
         }
 
-        private async Task<IReadOnlyList<RepositoryContent>> GetContents(IGitHubClient client, Repository repository, string branch)
-        {
-            try
-            {
-                return await client.Repository.Content.GetAllContentsByRef(repository.Owner.Login, repository.Name, branch).ConfigureAwait(false);
-            }
-            catch (NotFoundException exception)
-            {
-                /* 
-                 * NOTE: Repository that was just created (empty repository) doesn't have content this causes
-                 * Octokit.NotFoundException. This same thing would probably be throw if the whole repository
-                 * was missing, but we don't care for that case (no point to validate if repository doesn't exist.)
-                 */
-                _logger.LogWarning(exception, "Rule {ruleClass} / {ruleName}, Repository {repositoryName} caused {exceptionClass}. This may be a new repository, but if this persists, repository should be removed.",
-                 nameof(HasNewestPtcsJenkinsLibRule), RuleName, repository.Name, nameof(NotFoundException));
-                return Array.Empty<RepositoryContent>();
-            }
-        }
-
         private ValidationResult OkResult()
         {
             return new ValidationResult(RuleName, $"Update {LibraryName} to newest version. Newest version can be found in https://github.com/protacon/{LibraryName}/releases", true, DoNothing);

--- a/ValidationLibrary/Rules/IValidationRule.cs
+++ b/ValidationLibrary/Rules/IValidationRule.cs
@@ -12,7 +12,7 @@ namespace ValidationLibrary.Rules
         string RuleName { get; }
 
         Task Init(IGitHubClient ghClient);
-        
+
         Task<ValidationResult> IsValid(IGitHubClient client, Repository repository);
     }
 }


### PR DESCRIPTION
Readme-autofix commit should now be done only once.

Issue was caused by `Fix` not checking if the fix is already created.

Closes #235 