### PR TITLE
Temporarily disable codeowners validation

### DIFF
--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -128,6 +128,10 @@
                         {
                             "name": "GitHub:Organization",
                             "value": "[parameters('gitHubOrganization')]"
+                        },
+                        {
+                            "name": "Rules:HasCodeownersRule",
+                            "value": "disable"
                         }
                     ]
                 }


### PR DESCRIPTION
Codeowners validation rule is disabled for now. Rule itself is fine but I want to verify that existing rules work first (lot's of fixes for readme-rule etc)