### PR TITLE
Change to testing repo

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
             "program": "${workspaceFolder}/Runner/bin/Debug/netcoreapp3.1/Runner.dll",
-            "args": ["scan-selected", "-r", "repository-validator"],
+            "args": ["scan-selected", "-r", "repository-validator-testing"],
             "cwd": "${workspaceFolder}/Runner",
             // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window
             "console": "internalConsole",


### PR DESCRIPTION
I just thought the debugging json for test should point be default to the testing repository.
I know this is a pull request for one thing but thing you can just quickly accept or reject it.