### PR TITLE
Remove argument check from markdown because it breaks the generation.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,7 @@ podTemplate(label: pod.label,
             stage('Test') {
                 sh """
                     dotnet test
+                    dotnet run --project Runner -- generate-document
                 """
             }
         }

--- a/ValidationLibrary.MarkdownGenerator/MarkdownBuilder.cs
+++ b/ValidationLibrary.MarkdownGenerator/MarkdownBuilder.cs
@@ -21,7 +21,7 @@ namespace ValidationLibrary.MarkdownGenerator
 
         public void AppendLine(string text)
         {
-            if (string.IsNullOrWhiteSpace(text)) throw new ArgumentException(nameof(text));
+            if (text is null) throw new ArgumentNullException(nameof(text));
 
             _stringBuilder.AppendLine(text);
         }


### PR DESCRIPTION
Markdown generation was broken because it didn't allow for empty lines.
* Check only for null.
* Add markdown generation as a CI step.